### PR TITLE
Add prominent social follow CTAs

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Github, Linkedin, Compass, BookCopy, Shield, Waypoints } from 'lucide-react';
+import { Github, Linkedin, Compass, BookCopy, Shield, Waypoints, Twitter } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 const SOCIALS = [
-  { icon: <Github className="h-[18px] w-[18px]" />, href: 'https://github.com/anshaneja5/mldl.study', label: 'GitHub' },
-  { icon: <Linkedin className="h-[18px] w-[18px]" />, href: 'https://www.linkedin.com/in/anshaneja5/', label: 'LinkedIn' },
+  { icon: <Twitter className="h-[18px] w-[18px]" />, href: 'https://x.com/vedolos/', label: 'Follow on X', handle: '@vedolos', className: 'bg-[#0f1419] text-white' },
+  { icon: <Linkedin className="h-[18px] w-[18px]" />, href: 'https://www.linkedin.com/in/anshaneja5/', label: 'Connect on LinkedIn', handle: 'Ansh Aneja', className: 'bg-[#0a66c2] text-white' },
+  { icon: <Github className="h-[18px] w-[18px]" />, href: 'https://github.com/anshaneja5/mldl.study', label: 'GitHub', handle: 'Source code', className: 'glass text-ink' },
 ];
 
 const SECTIONS = [
@@ -67,9 +68,12 @@ const Footer = () => (
             </span>
           </Link>
           <p className="mt-4 max-w-xs text-sm leading-relaxed text-soft">
-            Simplifying Machine Learning &amp; Deep Learning education for everyone — curated, free, and open source.
+            Simplifying Machine Learning &amp; Deep Learning education, plus notes on Claude Code, Cursor, agentic coding, and the latest AI tools.
           </p>
-          <div className="mt-5 flex gap-2.5">
+          <div className="mt-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-aurora">Follow Ansh</p>
+          </div>
+          <div className="mt-3 grid max-w-md gap-2.5 sm:grid-cols-2">
             {SOCIALS.map((s, i) => (
               <a
                 key={i}
@@ -77,9 +81,13 @@ const Footer = () => (
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={s.label}
-                className="grid h-10 w-10 place-items-center rounded-xl glass text-soft transition-all duration-300 hover:text-ink hover:shadow-glow"
+                className={`flex items-center gap-2.5 rounded-2xl px-4 py-3 text-sm font-semibold transition-all duration-300 hover:-translate-y-0.5 hover:shadow-glow ${s.className}`}
               >
                 {s.icon}
+                <span className="flex flex-col leading-tight">
+                  <span>{s.label}</span>
+                  <span className="text-xs font-medium opacity-70">{s.handle}</span>
+                </span>
               </a>
             ))}
           </div>

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import ReactGA from 'react-ga4';
 import {
   ChevronDown, X, GitBranch, BookOpen, Map, ArrowRight, Sparkles, Zap,
-  Book, Code, Brain, Users, Play, Compass,
+  Book, Code, Brain, Users, Play, Compass, Linkedin, Twitter,
 } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { Helmet } from 'react-helmet';
@@ -32,6 +32,11 @@ const FEATURES = [
   { icon: <BookOpen className="h-5 w-5" />, title: 'Video Lectures', desc: 'Curated video content from top educators and practitioners in the field.', color: 'from-aurora-violet to-aurora-indigo' },
   { icon: <Code className="h-5 w-5" />, title: 'Hands-on Projects', desc: 'Practical exercises and real-world projects to apply your knowledge.', color: 'from-aurora-cyan to-aurora-blue' },
   { icon: <Brain className="h-5 w-5" />, title: 'Research Papers', desc: 'Access to foundational and cutting-edge research in AI and ML.', color: 'from-aurora-fuchsia to-aurora-violet' },
+];
+
+const SOCIAL_LINKS = [
+  { label: 'Follow on X', handle: '@vedolos', href: 'https://x.com/vedolos/', icon: <Twitter className="h-5 w-5" />, className: 'bg-[#0f1419] text-white hover:bg-black' },
+  { label: 'Connect on LinkedIn', handle: 'Ansh Aneja', href: 'https://www.linkedin.com/in/anshaneja5/', icon: <Linkedin className="h-5 w-5" />, className: 'bg-[#0a66c2] text-white hover:bg-[#084d94]' },
 ];
 
 const fadeUp = {
@@ -219,7 +224,36 @@ const HomePage = () => {
               </a>
             </motion.div>
 
-            <motion.div variants={fadeUp} custom={4} className="mt-8 flex flex-wrap items-center justify-center gap-x-7 gap-y-2 text-sm text-soft">
+            <motion.div
+              variants={fadeUp}
+              custom={4}
+              className="border-aurora glass-strong glass-sheen mx-auto mt-8 max-w-2xl rounded-3xl p-4 shadow-glass sm:p-5"
+            >
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-aurora">Follow the builder</p>
+              <h2 className="mt-1 font-display text-2xl font-bold text-ink sm:text-3xl">Follow Ansh for AI, Claude Code, Cursor, and build updates</h2>
+              <p className="mx-auto mt-2 max-w-lg text-sm leading-relaxed text-soft">
+                I share learning resources, roadmap updates, and practical notes on the latest AI tools, agentic coding, Claude Code, Cursor, ML, DL, and GenAI.
+              </p>
+              <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                {SOCIAL_LINKS.map((social) => (
+                  <a
+                    key={social.href}
+                    href={social.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`flex items-center justify-center gap-3 rounded-2xl px-5 py-4 text-left font-semibold shadow-lg transition-all duration-300 hover:-translate-y-0.5 hover:shadow-glow ${social.className}`}
+                  >
+                    {social.icon}
+                    <span className="flex flex-col leading-tight">
+                      <span>{social.label}</span>
+                      <span className="text-xs font-medium opacity-75">{social.handle}</span>
+                    </span>
+                  </a>
+                ))}
+              </div>
+            </motion.div>
+
+            <motion.div variants={fadeUp} custom={5} className="mt-8 flex flex-wrap items-center justify-center gap-x-7 gap-y-2 text-sm text-soft">
               <span className="inline-flex items-center gap-1.5"><Zap className="h-4 w-4 text-aurora-cyan" /> 100% Free</span>
               <span className="inline-flex items-center gap-1.5"><Users className="h-4 w-4 text-aurora-violet" /> Community-Driven</span>
               <span className="inline-flex items-center gap-1.5"><BookOpen className="h-4 w-4 text-aurora-blue" /> Real-World Skills</span>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Sun, Moon, Menu, X, Waypoints, ChevronDown, Coffee, Github } from 'lucide-react';
+import { Sun, Moon, Menu, X, Waypoints, ChevronDown, Coffee, Github, Linkedin, Twitter } from 'lucide-react';
 
 const PRIMARY = [
   { path: '/prerequisites', label: 'Prerequisites' },
@@ -21,6 +21,8 @@ const SECONDARY = [
 
 const BMC_URL = 'https://buymeacoffee.com/anshaneja';
 const REPO_URL = 'https://github.com/anshaneja5/mldl.study';
+const X_URL = 'https://x.com/vedolos/';
+const LINKEDIN_URL = 'https://www.linkedin.com/in/anshaneja5/';
 
 const Logo = () => (
   <Link to="/" className="group flex items-center gap-2.5">
@@ -172,6 +174,33 @@ const MobileSheet = ({ isOpen, onClose, darkMode, toggleDarkMode }) => {
           })}
         </nav>
 
+        <div className="mt-5 rounded-3xl border border-white/10 bg-white/[0.04] p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-aurora">Follow Ansh</p>
+          <p className="mt-1 text-sm text-soft">Get AI resources, Claude Code, Cursor, agentic coding, and build notes.</p>
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <a
+              href={X_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={onClose}
+              className="flex items-center justify-center gap-2 rounded-2xl bg-[#0f1419] px-4 py-3 text-sm font-semibold text-white shadow-lg"
+            >
+              <Twitter size={18} />
+              Follow on X
+            </a>
+            <a
+              href={LINKEDIN_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={onClose}
+              className="flex items-center justify-center gap-2 rounded-2xl bg-[#0a66c2] px-4 py-3 text-sm font-semibold text-white shadow-lg"
+            >
+              <Linkedin size={18} />
+              LinkedIn
+            </a>
+          </div>
+        </div>
+
         <div className="mt-5 flex items-center justify-between gap-3 border-t border-white/10 pt-5">
           <button
             onClick={toggleDarkMode}
@@ -218,6 +247,29 @@ const Navbar = ({ darkMode, toggleDarkMode }) => {
           <div className="hidden items-center gap-7 md:flex">
             <DesktopLinks />
             <div className="flex items-center gap-2 border-l border-white/10 pl-5">
+              <div className="hidden items-center gap-2 rounded-2xl glass px-2 py-1 lg:flex">
+                <span className="hidden text-xs font-semibold uppercase tracking-[0.18em] text-faint xl:inline">Follow</span>
+                <a
+                  href={X_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Follow Ansh on X"
+                  className="flex h-9 items-center gap-1.5 rounded-xl bg-[#0f1419] px-3 text-sm font-semibold text-white transition-all duration-300 hover:-translate-y-0.5 hover:shadow-glow"
+                >
+                  <Twitter className="h-[16px] w-[16px]" />
+                  <span>X</span>
+                </a>
+                <a
+                  href={LINKEDIN_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Connect with Ansh on LinkedIn"
+                  className="flex h-9 items-center gap-1.5 rounded-xl bg-[#0a66c2] px-3 text-sm font-semibold text-white transition-all duration-300 hover:-translate-y-0.5 hover:shadow-glow"
+                >
+                  <Linkedin className="h-[16px] w-[16px]" />
+                  <span>LinkedIn</span>
+                </a>
+              </div>
               <a
                 href={REPO_URL}
                 target="_blank"


### PR DESCRIPTION
## Summary

- Visitors now get clear X and LinkedIn follow CTAs above the fold, in the desktop nav, in the mobile menu, and in the footer.
- The follow copy now positions Ansh around AI learning resources, Claude Code, Cursor, agentic coding, ML/DL, and GenAI build updates.

## Test plan

- `npm run build`
- Edited files show no IDE lint diagnostics
- `npm run lint` still fails on existing repo-wide lint issues unrelated to this change

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.5](https://img.shields.io/badge/GPT_5.5-000000)
